### PR TITLE
pytest to requirements.txt (import error fix)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ auth-lib-profcomff
 profcomff-parse-lib
 profcomff-definitions
 virtualenv
+pytest


### PR DESCRIPTION
Исправляет ошибку импорта при локальном запуске aiflow при помощи добавления pytest в список requirements.txt

![изображение](https://github.com/user-attachments/assets/5f37b769-e732-42ab-be80-fa6f93f615bc)

